### PR TITLE
Document mmtf-python in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,10 @@ other optional Python dependencies, which can be installed later if needed:
 - mysqlclient, see https://github.com/PyMySQL/mysqlclient-python (optional)
   This is a fork of the older MySQLdb and is used by ``BioSQL`` to access a
   MySQL database. It is supported by PyPy.
+  
+- mmtf-python, see https://github.com/rcsb/mmtf-python (optional)
+  This provides support for the MMTF structure format and is used by
+  ``Bio.PDB.mmtf``.
 
 In addition there are a number of useful third party tools you may wish to
 install such as standalone NCBI BLAST, EMBOSS or ClustalW.


### PR DESCRIPTION
The `mmtf-python` optional dependency is required to use `Bio.PDB.mmtf`. This documents it in the README.

- [ X] I hereby agree to dual licence this and any previous contributions under both
the _Biopython License Agreement_ **AND** the _BSD 3-Clause License_.

- [ X] I have read the ``CONTRIBUTING.rst`` file, have run ``flake8`` locally, and
understand that AppVeyor and TravisCI will be used to confirm the Biopython unit
tests and style checks pass with these changes.

- [ X] I have added my name to the alphabetical contributors listings in the files
``NEWS.rst`` and ``CONTRIB.rst`` as part of this pull request, am listed
already, or do not wish to be listed. (*This acknowledgement is optional.*)
